### PR TITLE
Fix panic in GetAttributes on node or edge created from Decode

### DIFF
--- a/graphml/graphml.go
+++ b/graphml/graphml.go
@@ -239,10 +239,15 @@ func (gml *GraphML) Decode(r io.Reader) error {
 		} else if gr.EdgeDefault == edgeDirectionUndirected {
 			gr.edgesDirection = EdgeDirectionUndirected
 		}
-		// populate edges map
+		// populate edges map and link them to their graph
 		gr.edgesMap = make(map[string]*Edge)
 		for _, e := range gr.Edges {
 			gr.edgesMap[edgeIdentifier(e.Source, e.Target)] = e
+			e.graph = gr
+		}
+		// properly link nodes to their graph
+		for _, n := range gr.Nodes {
+			n.graph = gr
 		}
 	}
 

--- a/graphml/graphml_test.go
+++ b/graphml/graphml_test.go
@@ -72,6 +72,10 @@ func TestGraphML_Decode(t *testing.T) {
 		assert.Equal(t, desc, n.Description, "wrong node description at: %d", i)
 		// check attributes
 		checkAttributes(attributes, n.Data, KeyForNode, gml, t)
+		// check GetAttributes
+		attrs, err := n.GetAttributes()
+		assert.Nil(t, err, "failed to get attributes")
+		assert.Len(t, attrs, len(attributes), "wrong attribute number")
 	}
 
 	// check Edge elements
@@ -85,6 +89,10 @@ func TestGraphML_Decode(t *testing.T) {
 		assert.Equal(t, "test edge", e.Description, "wrong edge description: %v", e)
 		// check attributes
 		checkAttributes(attributes, e.Data, KeyForEdge, gml, t)
+		// check GetAttributes
+		attrs, err := e.GetAttributes()
+		assert.Nil(t, err, "failed to get attributes")
+		assert.Len(t, attrs, len(attributes), "wrong attribute number")
 	}
 }
 


### PR DESCRIPTION
-   Fixes the two following panics in GetAttributes on node or edge created from Decode (you can check that they happen by cherry-picking the second commit and running the tests):

    ```
    panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    	panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0x5be682]
    
    goroutine 8 [running]:
    testing.tRunner.func1.2({0x5e54e0, 0x7a6170})
    	/usr/lib/go-1.19/src/testing/testing.go:1396 +0x24e
    testing.tRunner.func1()
    	/usr/lib/go-1.19/src/testing/testing.go:1399 +0x39f
    panic({0x5e54e0, 0x7a6170})
    	/usr/lib/go-1.19/src/runtime/panic.go:884 +0x212
    github.com/yaricom/goGraphML/graphml.(*Node).GetAttributes(...)
    	/home/nicolas/Sources/goGraphML/graphml/graphml.go:399
    github.com/yaricom/goGraphML/graphml.TestGraphML_Decode(0x0?)
    	/home/nicolas/Sources/goGraphML/graphml/graphml_test.go:76 +0xac2
    testing.tRunner(0xc00018ed00, 0x640600)
    	/usr/lib/go-1.19/src/testing/testing.go:1446 +0x10b
    created by testing.(*T).Run
    	/usr/lib/go-1.19/src/testing/testing.go:1493 +0x35f
    ```
    
    ```
    panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    	panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0x5bebec]
    
    goroutine 8 [running]:
    testing.tRunner.func1.2({0x5e54e0, 0x7a6170})
    	/usr/lib/go-1.19/src/testing/testing.go:1396 +0x24e
    testing.tRunner.func1()
    	/usr/lib/go-1.19/src/testing/testing.go:1399 +0x39f
    panic({0x5e54e0, 0x7a6170})
    	/usr/lib/go-1.19/src/runtime/panic.go:884 +0x212
    github.com/yaricom/goGraphML/graphml.(*Edge).GetAttributes(...)
    	/home/nicolas/Sources/goGraphML/graphml/graphml.go:408
    github.com/yaricom/goGraphML/graphml.TestGraphML_Decode(0x0?)
    	/home/nicolas/Sources/goGraphML/graphml/graphml_test.go:93 +0x100c
    testing.tRunner(0xc00018ed00, 0x640600)
    	/usr/lib/go-1.19/src/testing/testing.go:1446 +0x10b
    created by testing.(*T).Run
    	/usr/lib/go-1.19/src/testing/testing.go:1493 +0x35f
    ```

-   Add regression test for ad7bff3
