### PR TITLE
Return attr as string by default, instead of error

### DIFF
--- a/graphml/graphml.go
+++ b/graphml/graphml.go
@@ -571,9 +571,7 @@ func valueByType(val string, keyType DataType) (interface{}, error) {
 		} else {
 			return fVal, nil
 		}
-	case StringType:
-		return val, nil
 	default:
-		return nil, errors.New(fmt.Sprintf("unsupported value type: %s", keyType))
+		return val, nil
 	}
 }


### PR DESCRIPTION
This allows to get the properties of complex attributes even if goGraphML does not know how to handle them.

As demonstrated here : http://graphml.graphdrawing.org/primer/graphml-primer.html#Complex, attributes can have complex data types, especially when the specification is extended. By returning the string value by default instead of error, we can then let the consumer handle the complex value by parsing it himself. Returning an error in this case is really not helpful as it even prevents from getting the rest of the attributes.


For a little bit more context, I need to parse [this graphML](https://static.club1.fr/nicolas/random-other/netgraph.xml), and without this change I only get errors when I call the GetAttributes() function on nodes.