### PR TITLE
Allow to parse empty data with empty default string key

### DIFF
--- a/data/test_graph_default_empty_string.xml
+++ b/data/test_graph_default_empty_string.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+    <key id="key0" for="node" attr.name="string-key" attr.type="string">
+        <default></default>
+    </key>
+    <graph edgedefault="directed" parse.nodeids="canonical" parse.edgeids="canonical" parse.order="nodesfirst">
+        <node id="n0">
+            <desc>test node #1</desc>
+            <data key="key0"></data>
+        </node>
+    </graph>
+</graphml>
+

--- a/graphml/graphml.go
+++ b/graphml/graphml.go
@@ -442,7 +442,7 @@ func attributesForData(data []*Data, gml *GraphML) (map[string]interface{}, erro
 		}
 		// use data value of default value
 		dataValue := d.Value
-		if dataValue == "" {
+		if dataValue == "" && key.KeyType != StringType {
 			if key.DefaultValue != "" {
 				dataValue = key.DefaultValue
 			} else {

--- a/graphml/graphml_test.go
+++ b/graphml/graphml_test.go
@@ -81,6 +81,44 @@ func TestGraphML_Decode_keyTypeDefault(t *testing.T) {
 	assert.Equal(t, key.KeyType, IntType)
 }
 
+func TestGraphML_Decode_emptyStringDefault(t *testing.T) {
+	graphFile, err := os.Open("../data/test_graph_default_empty_string.xml")
+	require.NoError(t, err, "failed to open file")
+	// decode
+	gml := NewGraphML("")
+	err = gml.Decode(graphFile)
+	require.NoError(t, err, "failed to decode")
+
+	// test results
+	attributes := make(map[string]interface{})
+	attributes["string-key"] = ""
+
+	// check Graph element
+	//
+	require.Len(t, gml.Graphs, 1, "wrong graphs number")
+	graph := gml.Graphs[0]
+
+	// check Node elements
+	//
+	require.Len(t, graph.Nodes, 1, "wrong nodes number")
+	for i, n := range graph.Nodes {
+		id := fmt.Sprintf("n%d", i)
+		assert.Equal(t, id, n.ID, "wrong node ID at: %d", i)
+		desc := fmt.Sprintf("test node #%d", i+1)
+		assert.Equal(t, desc, n.Description, "wrong node description at: %d", i)
+		// check GetAttributes
+		attrs, err := n.GetAttributes()
+		require.NoError(t, err, "failed to get attributes")
+		assert.Equal(t, attributes, attrs)
+	}
+
+	// check Key types was set properly
+	//
+	key := gml.GetKey("string-key", KeyForNode)
+	require.NotNil(t, key, "key expected")
+	assert.Equal(t, key.KeyType, StringType)
+}
+
 func TestGraphML_Decode(t *testing.T) {
 	graphFile, err := os.Open("../data/test_graph.xml")
 	require.NoError(t, err, "failed to open file")


### PR DESCRIPTION
Empty string `""` is a valid value for a string attribute and for its default value. We don't want to return an error if a string attribute's value is empty string.