### PR TITLE
Omit empty for attribute of key element

### DIFF
--- a/graphml/graphml.go
+++ b/graphml/graphml.go
@@ -100,7 +100,7 @@ type Key struct {
 	// The ID of this key element (in form dX, where X denotes the number of occurrences of the key element before the current one)
 	ID string `xml:"id,attr"`
 	// The name of element this key is for (graphml|graph|node|edge|hyperedge|port|endpoint|all)
-	Target KeyForElement `xml:"for,attr"`
+	Target KeyForElement `xml:"for,attr,omitempty"`
 	// The name of data-function associated with this key
 	Name string `xml:"attr.name,attr"`
 	// The type of input to the data-function associated with this key. (Allowed values: boolean, int, long, float, double, string)

--- a/graphml/graphml_test.go
+++ b/graphml/graphml_test.go
@@ -234,6 +234,23 @@ func TestGraphML_Encode(t *testing.T) {
 	assert.Equal(t, resString, outBuf.String())
 }
 
+func TestGraphML_Encode_EmptyFor(t *testing.T) {
+	// build GraphML
+	gml := NewGraphML("TestGraphML_Encode_EmptyFor")
+
+	// register common data-function for all elements
+	keyForAllName := "keyForAll"
+	_, err := gml.RegisterKey("", keyForAllName, "", reflect.String, nil)
+	require.NoError(t, err, "failed to register key")
+
+	// encode
+	outBuf := &bytes.Buffer{}
+	err = gml.Encode(outBuf, false)
+
+	// check results
+	assert.NotContains(t, outBuf.String(), "for=\"\"", "a key with an empty target should omit the for attribute")
+}
+
 func TestGraphML_AddGraph(t *testing.T) {
 	description := "test graph"
 	gml := NewGraphML("")


### PR DESCRIPTION
See <http://graphml.graphdrawing.org/specification/dtd.html#default>

    for (graph|node|edge|hyperedge|port|endpoint|all) "all"

`for=""` is not a valid value, it should be omited if empty.
