### PR TITLE
Fix duplicated IDs when adding data to parsed graphML

### DIFF
--- a/data/test_graph_1_indexed.xml
+++ b/data/test_graph_1_indexed.xml
@@ -1,0 +1,23 @@
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+    <desc>TestGraphML_Encode</desc>
+    <key id="d1" for="all" attr.name="double" attr.type="double">
+        <desc>common double data-function</desc>
+        <default>10.2</default>
+    </key>
+    <graph id="g1" edgedefault="directed">
+        <desc>test graph</desc>
+        <node id="n1">
+            <desc>test node #1</desc>
+            <data key="d1"/>
+        </node>
+        <node id="n2">
+            <desc>test node #2</desc>
+        </node>
+        <edge id="e1" source="n1" target="n2">
+            <desc>test edge</desc>
+        </edge>
+        <data key="d1">3.14</data>
+    </graph>
+</graphml>

--- a/graphml/graphml.go
+++ b/graphml/graphml.go
@@ -280,8 +280,13 @@ func (gml *GraphML) RegisterKey(target KeyForElement, name, description string, 
 		return nil, errors.New(fmt.Sprintf("key with given name already registered: %s", name))
 	}
 	count := len(gml.Keys)
+	var id string
+	for found := true; found; _, found = gml.keysById[id] {
+		id = fmt.Sprintf("d%d", count)
+		count++
+	}
 	key = &Key{
-		ID:          fmt.Sprintf("d%d", count),
+		ID:          id,
 		Target:      target,
 		Name:        name,
 		Description: description,
@@ -380,8 +385,20 @@ func (gml *GraphML) AddGraph(description string, edgeDefault EdgeDirection, attr
 		return nil, errors.New("default edge direction must be provided")
 	}
 
+	var id string
+	for found := true; found; {
+		id = fmt.Sprintf("g%d", count)
+		found = false
+		for _, g := range gml.Graphs {
+			if g.ID == id {
+				found = true
+				count++
+				break
+			}
+		}
+	}
 	graph = &Graph{
-		ID:             fmt.Sprintf("g%d", count),
+		ID:             id,
 		EdgeDefault:    edgeDirection,
 		Description:    description,
 		Nodes:          make([]*Node, 0),
@@ -404,8 +421,13 @@ func (gml *GraphML) AddGraph(description string, edgeDefault EdgeDirection, attr
 // AddNode adds node to the graph with provided additional attributes and description
 func (gr *Graph) AddNode(attributes map[string]interface{}, description string) (node *Node, err error) {
 	count := len(gr.Nodes)
+	var id string
+	for found := true; found; _, found = gr.nodesMap[id] {
+		id = fmt.Sprintf("n%d", count)
+		count++
+	}
 	node = &Node{
-		ID:          fmt.Sprintf("n%d", count),
+		ID:          id,
 		Description: description,
 		Data:        make([]*Data, 0),
 	}
@@ -444,8 +466,20 @@ func (gr *Graph) AddEdge(source, target *Node, attributes map[string]interface{}
 	}
 
 	count := len(gr.Edges)
+	var id string
+	for found := true; found; {
+		id = fmt.Sprintf("e%d", count)
+		found = false
+		for _, e := range gr.Edges {
+			if e.ID == id {
+				found = true
+				count++
+				break
+			}
+		}
+	}
 	edge = &Edge{
-		ID:          fmt.Sprintf("e%d", count),
+		ID:          id,
 		Source:      source.ID,
 		Target:      target.ID,
 		Description: description,

--- a/graphml/graphml_test.go
+++ b/graphml/graphml_test.go
@@ -941,3 +941,33 @@ func TestGraphML_stringValueIfSupported(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, testString, res)
 }
+
+func TestGraphML_1Indexed(t *testing.T) {
+	graphFile, err := os.Open("../data/test_graph_1_indexed.xml")
+	require.NoError(t, err, "failed to open file")
+	// decode
+	gml := NewGraphML("")
+	err = gml.Decode(graphFile)
+	require.NoError(t, err, "failed to decode")
+
+	nilAttrs := map[string]interface{}{}
+
+	graph, err := gml.AddGraph("test graph", EdgeDirectionDirected, nilAttrs)
+	require.NoError(t, err, "failed to add graph")
+	assert.Equal(t, "g2", graph.ID)
+
+	key, err := gml.RegisterKey(KeyForAll, "test", "test key", reflect.String, nil)
+	require.NoError(t, err, "failed to add key")
+	assert.Equal(t, "d2", key.ID)
+
+	graph1 := gml.Graphs[0]
+
+	node3, err := graph1.AddNode(nilAttrs, "test node")
+	require.NoError(t, err, "failed to add node")
+	assert.Equal(t, "n3", node3.ID)
+
+	node1 := graph1.GetNode("n1")
+	edge, err := graph1.AddEdge(node1, node3, nilAttrs, EdgeDirectionDefault, "test edge")
+	require.NoError(t, err, "failed to add edge")
+	assert.Equal(t, "e2", edge.ID)
+}


### PR DESCRIPTION
We make sure that the ID does not exists in the document before using it, by incrementing its value as long as needed.
